### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER bot
 WORKDIR ~
 
 COPY --chown=bot:bot requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-warn-script-location
 
 COPY --chown=bot:bot . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3-alpine
 
-RUN mkdir -p /usr/src/bot
-WORKDIR /usr/src/bot
+RUN adduser -D bot
+USER bot
 
-COPY requirements.txt .
+WORKDIR ~
+
+COPY --chown=bot:bot requirements.txt .
 RUN pip install -r requirements.txt
 
-COPY . .
+COPY --chown=bot:bot . .
 
 CMD [ "python3", "main.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+
+RUN mkdir -p /usr/src/bot
+WORKDIR /usr/src/bot
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+
+CMD [ "python3", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-CMD [ "python3", "main.py"]
+CMD [ "python3", "main.py" ]


### PR DESCRIPTION
- adds initial `Dockerfile` for bot application

Using the `alpine` image results in a image size of 182mb.

If we want to automate this, we will need to use GitHub's secret store and populate the `.env` file at build time with production connection details.