### PR TITLE
fix/169-God-Rank-Sync

### DIFF
--- a/ironforgedbot/commands/admin/sync_members.py
+++ b/ironforgedbot/commands/admin/sync_members.py
@@ -62,6 +62,9 @@ async def sync_members(guild: discord.Guild) -> list[list]:
                         change_text += "Nickname changed "
 
                     discord_rank = get_rank_from_member(discord_member)
+                    if discord_rank in GOD_ALIGNMENT.list():
+                        discord_rank = RANK.GOD
+
                     if discord_rank:
                         if member.rank != discord_rank:
                             await service.change_rank(member.id, RANK(discord_rank))


### PR DESCRIPTION
Fixed god ranks in member Sync. Used black formatter on local before creating branch on Github. 