### PR TITLE
fix/178-update-prospect-period

### DIFF
--- a/ironforgedbot/tasks/job_refresh_ranks.py
+++ b/ironforgedbot/tasks/job_refresh_ranks.py
@@ -30,7 +30,7 @@ from ironforgedbot.services.score_service import (
 
 logger: logging.Logger = logging.getLogger(name=__name__)
 
-PROBATION_DAYS = 14
+PROBATION_DAYS = 28
 
 
 async def job_refresh_ranks(

--- a/tests/tasks/job_refresh_ranks_test.py
+++ b/tests/tasks/job_refresh_ranks_test.py
@@ -172,7 +172,7 @@ class RefreshRanksTest(unittest.IsolatedAsyncioTestCase):
         expected_messages = [
             call("Rank check progress: [0/1]"),
             call(
-                f"{member.mention} has completed their **14 day** probation period "
+                f"{member.mention} has completed their **28 day** probation period "
                 "and is now eligible for  **Iron** rank."
             ),
             call("Finished rank check: [1/1]"),
@@ -265,7 +265,7 @@ class RefreshRanksTest(unittest.IsolatedAsyncioTestCase):
         expected_messages = [
             call("Rank check progress: [0/1]"),
             call(
-                f"{member.mention} has completed their **14 day** probation period and "
+                f"{member.mention} has completed their **28 day** probation period and "
                 f"is now eligible for  **Mithril** rank."
             ),
             call("Finished rank check: [1/1]"),


### PR DESCRIPTION
Just updating the days from 14 to 28 as per leadership request. No additional changes made. I know we have an open issue for test scripts. I tested this on my bot server and it showed the new timeframes as shown below after I gave myself prospect, I cannot do a members activity check since I don't have a WOM API Key, but I checked the file and it looks to have similar logic as the score and breakdown in checking ranks.

<img width="588" height="365" alt="image" src="https://github.com/user-attachments/assets/cf58a624-2609-403e-b2cd-d341c4995539" />
